### PR TITLE
added quick re-select mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Move visual selection up and down a line:
 vnoremap J :m '>+1<CR>gv=gv
 vnoremap K :m '<-2<CR>gv=gv
 ```
+Quickly re-select either the last pasted or changed text:
+```vim
+noremap gV `[v`]
+```
 
 ## Avoiding RSI
 


### PR DESCRIPTION
Simple and easy mapping that allows for you to either quickly re-select the last pasted or changed text.

On a side-note, it might also be nice to add a "autocmd" (Autocommands) section which are great for easy configurations. Some examples, 

removing trailing white-space on save 
`autocmd BufWritePre * :%s/\s\+$//e`

auto reload/source .vimrc after save
```
if has ('autocmd')
	augroup vimrc
		autocmd! BufWritePost $MYVIMRC source % | echom ".vimrc reloaded" . $MYVIMRC | redraw
	augroup END
endif
```